### PR TITLE
Maintain html syntax highlighting in twig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6902,7 +6902,7 @@
     },
     "packages/language-server": {
       "name": "twig-language-server",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Mozilla Public License 2.0",
       "dependencies": {
         "tree-sitter-twig": "^0.4.0",
@@ -6918,10 +6918,10 @@
     },
     "packages/vscode": {
       "name": "vscode-twig",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Mozilla Public License 2.0",
       "dependencies": {
-        "twig-language-server": "^0.2.2",
+        "twig-language-server": "^0.2.3",
         "vscode-languageclient": "^8.1.0"
       },
       "devDependencies": {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -49,6 +49,16 @@
         "configuration": "./languages/twig.configuration.json"
       }
     ],
+    "grammars": [
+      {
+        "language": "twig",
+        "scopeName": "text.html.twig",
+        "path": "./syntaxes/twig.tmLanguage.json",
+        "embeddedLanguages": {
+          "text.html.derivative": "html"
+        }
+      }
+    ],
     "semanticTokenTypes": [
       {
         "id": "embedded_begin",

--- a/packages/vscode/syntaxes/twig.tmLanguage.json
+++ b/packages/vscode/syntaxes/twig.tmLanguage.json
@@ -1,0 +1,669 @@
+{
+  "name": "Twig",
+  "scopeName": "text.html.twig",
+  "patterns": [
+    {
+      "include": "#yfm"
+    },
+    {
+      "include": "#block_comments"
+    },
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#end_block"
+    },
+    {
+      "include": "#inline_script"
+    },
+    {
+      "include": "#html_tags"
+    },
+    {
+      "include": "text.html.basic"
+    },
+    {
+      "include": "#string"
+    },
+    {
+      "begin": "{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.begin.bracket.curly.twig"
+        }
+      },
+      "end": "}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.end.bracket.curly.twig"
+        }
+      },
+      "patterns": [
+        {
+          "include": "$self"
+        }
+      ]
+    },
+    {
+      "begin": "\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.array.begin.twig"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.array.end.twig"
+        }
+      },
+      "patterns": [
+        {
+          "include": "$self"
+        }
+      ]
+    }
+  ],
+  "repository": {
+    "html_tags": {
+      "patterns": [
+        {
+          "begin": "(<)([a-zA-Z0-9:-]+)(?=[^>]*></\\2>)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.html"
+            }
+          },
+          "end": "(>(<)/)(\\2)(>)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "meta.scope.between-tag-pair.html"
+            },
+            "3": {
+              "name": "entity.name.tag.html"
+            },
+            "4": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "name": "meta.tag.any.html",
+          "patterns": [
+            {
+              "include": "#tag-stuff"
+            }
+          ]
+        },
+        {
+          "begin": "(<\\?)(xml)",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.xml.html"
+            }
+          },
+          "end": "(\\?>)",
+          "name": "meta.tag.preprocessor.xml.html",
+          "patterns": [
+            {
+              "include": "#tag_generic_attribute"
+            },
+            {
+              "include": "#string"
+            }
+          ]
+        },
+        {
+          "begin": "<!--",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.comment.html"
+            }
+          },
+          "end": "--\\s*>",
+          "name": "comment.block.html",
+          "patterns": [
+            {
+              "match": "--",
+              "name": "invalid.illegal.bad-comments-or-CDATA.html"
+            }
+          ]
+        },
+        {
+          "begin": "<!",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "end": ">",
+          "name": "meta.tag.sgml.html",
+          "patterns": [
+            {
+              "begin": "(DOCTYPE|doctype)",
+              "captures": {
+                "1": {
+                  "name": "entity.name.tag.doctype.html"
+                }
+              },
+              "end": "(?=>)",
+              "name": "meta.tag.sgml.doctype.html",
+              "patterns": [
+                {
+                  "match": "\"[^\">]*\"",
+                  "name": "string.quoted.double.doctype.identifiers-and-DTDs.html"
+                }
+              ]
+            },
+            {
+              "begin": "\\[CDATA\\[",
+              "end": "]](?=>)",
+              "name": "constant.other.inline-data.html"
+            },
+            {
+              "match": "(\\s*)(?!--|>)\\S(\\s*)",
+              "name": "invalid.illegal.bad-comments-or-CDATA.html"
+            }
+          ]
+        },
+        {
+          "begin": "(?:^\\s+)?(<)((?i:style))\\b(?![^>]*/>)",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.style.html"
+            },
+            "3": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "end": "(</)((?i:style))(>)(?:\\s*\\n)?",
+          "name": "source.css.embedded.html",
+          "patterns": [
+            {
+              "include": "#tag-stuff"
+            },
+            {
+              "begin": "(>)",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.definition.tag.html"
+                }
+              },
+              "end": "(?=</(?i:style))",
+              "patterns": [
+                {
+                  "include": "source.css"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(?:^\\s+)?(<)((?i:script))\\b(?![^>]*/>)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.script.html"
+            }
+          },
+          "end": "(?<=</(script|SCRIPT))(>)(?:\\s*\\n)?",
+          "endCaptures": {
+            "2": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "name": "source.js.embedded.html",
+          "patterns": [
+            {
+              "include": "#tag-stuff"
+            },
+            {
+              "begin": "(?<!</(?:script|SCRIPT))(>)",
+              "captures": {
+                "1": {
+                  "name": "punctuation.definition.tag.html"
+                },
+                "2": {
+                  "name": "entity.name.tag.script.html"
+                }
+              },
+              "end": "(</)((?i:script))",
+              "patterns": [
+                {
+                  "captures": {
+                    "1": {
+                      "name": "punctuation.definition.comment.js"
+                    }
+                  },
+                  "match": "(//).*?((?=</script)|$\\n?)",
+                  "name": "comment.line.double-slash.js"
+                },
+                {
+                  "begin": "/\\*",
+                  "captures": {
+                    "0": {
+                      "name": "punctuation.definition.comment.js"
+                    }
+                  },
+                  "end": "\\*/|(?=</script)",
+                  "name": "comment.block.js"
+                },
+                {
+                  "include": "source.js"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "(</?)((?i:body|head|html)\\b)",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.structure.any.html"
+            }
+          },
+          "end": "(>)",
+          "name": "meta.tag.structure.any.html",
+          "patterns": [
+            {
+              "include": "#tag-stuff"
+            }
+          ]
+        },
+        {
+          "begin": "(</?)((?i:address|blockquote|dd|div|header|section|footer|aside|nav|dl|dt|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|hr|menu|pre)\\b)",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.block.any.html"
+            }
+          },
+          "end": "(>)",
+          "name": "meta.tag.block.any.html",
+          "patterns": [
+            {
+              "include": "#tag-stuff"
+            }
+          ]
+        },
+        {
+          "begin": "(</?)((?i:a|abbr|acronym|area|b|base|basefont|bdo|big|br|button|caption|cite|code|col|colgroup|del|dfn|em|font|head|html|i|img|input|ins|isindex|kbd|label|legend|li|link|map|meta|noscript|optgroup|option|param|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|var)\\b)",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.inline.any.html"
+            }
+          },
+          "end": "((?: ?/)?>)",
+          "name": "meta.tag.inline.any.html",
+          "patterns": [
+            {
+              "include": "#tag-stuff"
+            }
+          ]
+        },
+        {
+          "begin": "(</?)([a-zA-Z0-9:-]+)",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            }
+          },
+          "end": "(>)",
+          "name": "meta.tag.other.html",
+          "patterns": [
+            {
+              "include": "#tag-stuff"
+            }
+          ]
+        },
+        {
+          "begin": "(</?)([a-zA-Z0-9{}:-]+)",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.tokenised.html"
+            }
+          },
+          "end": "(>)",
+          "name": "meta.tag.tokenised.html",
+          "patterns": [
+            {
+              "include": "#tag-stuff"
+            }
+          ]
+        },
+        {
+          "include": "#entities"
+        },
+        {
+          "match": "<>",
+          "name": "invalid.illegal.incomplete.html"
+        },
+        {
+          "match": "<",
+          "name": "invalid.illegal.bad-angle-bracket.html"
+        }
+      ]
+    },
+    "entities": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.entity.html"
+            },
+            "3": {
+              "name": "punctuation.definition.entity.html"
+            }
+          },
+          "name": "constant.character.entity.html",
+          "match": "(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)"
+        },
+        {
+          "name": "invalid.illegal.bad-ampersand.html",
+          "match": "&"
+        }
+      ]
+    },
+    "end_block": {
+      "begin": "(\\{\\%)([a-zA-Z0-9/_\\.-]+)\\s*",
+      "end": "(\\%\\})",
+      "name": "meta.function.block.end.twig",
+      "endCaptures": {
+        "1": {
+          "name": "support.constant.twig"
+        }
+      },
+      "beginCaptures": {
+        "1": {
+          "name": "support.constant.twig"
+        },
+        "2": {
+          "name": "support.constant.twig keyword.control"
+        },
+        "3": {
+          "name": "support.constant.twig keyword.control"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#string"
+        }
+      ]
+    },
+    "yfm": {
+      "patterns": [
+        {
+          "patterns": [
+            {
+              "include": "source.yaml"
+            }
+          ],
+          "begin": "(?<!\\s)---\\n$",
+          "end": "^---\\s",
+          "name": "markup.raw.yaml.front-matter"
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "begin": "\\{\\#",
+          "end": "\\#\\}",
+          "name": "comment.block.twig"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.comment.html"
+            }
+          },
+          "begin": "<!--",
+          "end": "-{2,3}\\s*>",
+          "name": "comment.block.html",
+          "patterns": [
+            {
+              "name": "invalid.illegal.bad-comments-or-CDATA.html",
+              "match": "--"
+            }
+          ]
+        }
+      ]
+    },
+    "block_comments": {
+      "patterns": [
+        {
+          "begin": "\\{\\#",
+          "end": "\\#\\}",
+          "name": "comment.block.twig"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.comment.html"
+            }
+          },
+          "begin": "<!--",
+          "end": "-{2,3}\\s*>",
+          "name": "comment.block.html",
+          "patterns": [
+            {
+              "name": "invalid.illegal.bad-comments-or-CDATA.html",
+              "match": "--"
+            }
+          ]
+        }
+      ]
+    },
+    "string-single-quoted": {
+      "begin": "'",
+      "end": "'",
+      "name": "string.quoted.single.twig",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.end.html"
+        }
+      },
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.begin.html"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#escaped-single-quote"
+        },
+        {
+          "include": "#block_comments"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#end_block"
+        }
+      ]
+    },
+    "string-double-quoted": {
+      "begin": "\"",
+      "end": "\"",
+      "name": "string.quoted.double.twig",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.html"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.html"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#escaped-double-quote"
+        },
+        {
+          "include": "#block_comments"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#end_block"
+        }
+      ]
+    },
+    "string": {
+      "patterns": [
+        {
+          "include": "#string-single-quoted"
+        },
+        {
+          "include": "#string-double-quoted"
+        }
+      ]
+    },
+    "inline_script": {
+      "begin": "(?:^\\s+)?(<)((?i:script))\\b(?:.*(type)=([\"'][\"']))(?![^>]*/>)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.html"
+        },
+        "2": {
+          "name": "entity.name.tag.script.html"
+        },
+        "3": {
+          "name": "entity.other.attribute-name.html"
+        },
+        "4": {
+          "name": "string.quoted.double.html"
+        }
+      },
+      "end": "(?<=</(script|SCRIPT))(>)(?:\\s*\\n)?",
+      "endCaptures": {
+        "2": {
+          "name": "punctuation.definition.tag.html"
+        }
+      },
+      "name": "source.twig.embedded.html",
+      "patterns": [
+        {
+          "include": "#tag-stuff"
+        },
+        {
+          "begin": "(?<!</(?:script|SCRIPT))(>)",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.script.html"
+            }
+          },
+          "end": "(</)((?i:script))",
+          "patterns": [
+            {
+              "include": "#block_comments"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#end_block"
+            },
+            {
+              "include": "#html_tags"
+            },
+            {
+              "include": "text.html.basic"
+            }
+          ]
+        }
+      ]
+    },
+    "tag_generic_attribute": {
+      "begin": "\\b([a-zA-Z0-9_-]+)\\b\\s*(=?)",
+      "captures": {
+        "1": {
+          "name": "entity.other.attribute-name.generic.html"
+        },
+        "2": {
+          "name": "punctuation.separator.key-value.html"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#string"
+        }
+      ],
+      "name": "entity.other.attribute-name.html",
+      "end": "(?<='|\"|)"
+    },
+    "tag_id_attribute": {
+      "begin": "\\b(id)\\b\\s*(=)",
+      "captures": {
+        "1": {
+          "name": "entity.other.attribute-name.id.html"
+        },
+        "2": {
+          "name": "punctuation.separator.key-value.html"
+        }
+      },
+      "end": "(?<='|\"|)",
+      "name": "meta.attribute-with-value.id.html",
+      "patterns": [
+        {
+          "include": "#string"
+        }
+      ]
+    },
+    "tag-stuff": {
+      "patterns": [
+        {
+          "include": "#tag_id_attribute"
+        },
+        {
+          "include": "#tag_generic_attribute"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#block_comments"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#end_block"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
So I adapted the [Handlebars `tmLanguage.json`](https://github.com/microsoft/vscode/blob/main/extensions/handlebars/syntaxes/Handlebars.tmLanguage.json) and some of the [PHP `tmLanguage.json`](https://github.com/microsoft/vscode/blob/main/extensions/php/syntaxes/php.tmLanguage.json) so that HTML would still be syntax highlighted. Honestly, I understand very little of how language extensions for VSCode work, so I'm not 100% sure what is and isn't needed, but it does seem to work well. 

Let me know what you think!