### PR TITLE
Resolve Twig filters, functions, globals via `debug:twig` command.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6902,7 +6902,7 @@
     },
     "packages/language-server": {
       "name": "twig-language-server",
-      "version": "0.2.3",
+      "version": "0.4.0",
       "license": "Mozilla Public License 2.0",
       "dependencies": {
         "tree-sitter-twig": "^0.4.0",
@@ -6918,10 +6918,10 @@
     },
     "packages/vscode": {
       "name": "vscode-twig",
-      "version": "0.2.3",
+      "version": "0.4.0",
       "license": "Mozilla Public License 2.0",
       "dependencies": {
-        "twig-language-server": "^0.2.3",
+        "twig-language-server": "^0.4.0",
         "vscode-languageclient": "^8.1.0"
       },
       "devDependencies": {

--- a/packages/language-server/src/completions/completion-provider.ts
+++ b/packages/language-server/src/completions/completion-provider.ts
@@ -22,8 +22,20 @@ export class CompletionProvider {
     );
   }
 
-  async initializeGlobalsFromCommand(phpBinConsoleCommand: string) {
-    this.twigInfo = await getSectionsFromPhpDebugTwig(phpBinConsoleCommand + ' debug:twig');
+  async initializeGlobalsFromCommand(phpBinConsoleCommand: string | undefined) {
+    this.twigInfo = phpBinConsoleCommand
+      ? await getSectionsFromPhpDebugTwig(phpBinConsoleCommand + ' debug:twig')
+      : undefined;
+
+    if (this.twigInfo) {
+      console.info(
+        'Twig info initialized. '
+        + `Detected ${this.twigInfo.Functions.length} functions, `
+        + `${this.twigInfo.Filters.length} filters and ${this.twigInfo.Globals.length} globals.`
+      );
+    } else {
+      console.error('Twig info not initialized.');
+    }
   }
 
   async onCompletion(params: CompletionParams) {

--- a/packages/language-server/src/completions/completion-provider.ts
+++ b/packages/language-server/src/completions/completion-provider.ts
@@ -7,9 +7,11 @@ import { localVariables } from './local-variables';
 import { functions } from './functions';
 import { filters } from './filters';
 import { forLoop } from './for-loop';
+import { TwigDebugInfo, getSectionsFromPhpDebugTwig } from './debug-twig';
 
 export class CompletionProvider {
   server: Server;
+  twigInfo?: TwigDebugInfo;
 
   constructor(server: Server) {
     this.server = server;
@@ -18,6 +20,10 @@ export class CompletionProvider {
     this.server.connection.onCompletionResolve(
       this.onCompletionResolve.bind(this)
     );
+  }
+
+  async initializeGlobalsFromCommand(phpBinConsoleCommand: string) {
+    this.twigInfo = await getSectionsFromPhpDebugTwig(phpBinConsoleCommand + ' debug:twig');
   }
 
   async onCompletion(params: CompletionParams) {
@@ -37,9 +43,9 @@ export class CompletionProvider {
     }
 
     [
-      globalVariables(cursorNode),
-      functions(cursorNode),
-      filters(cursorNode),
+      globalVariables(cursorNode, this.twigInfo?.Globals || []),
+      functions(cursorNode, this.twigInfo?.Functions || []),
+      filters(cursorNode, this.twigInfo?.Filters || []),
       localVariables(cursorNode),
       forLoop(cursorNode),
       templatePaths(

--- a/packages/language-server/src/completions/debug-twig/index.ts
+++ b/packages/language-server/src/completions/debug-twig/index.ts
@@ -1,0 +1,16 @@
+export * from './types';
+
+import { promisify } from 'node:util';
+import { parseSections } from './parse-sections';
+
+const exec: (cmd: string) => Promise<{ stdout: string, stderr: string }> = promisify(require('node:child_process').exec);
+
+export const getSectionsFromPhpDebugTwig = async (debugTwigCommand: string) => {
+  const { stdout, stderr } = await exec(debugTwigCommand).catch((err) => err);
+
+  if (stderr) {
+    return undefined;
+  }
+
+  return parseSections(stdout);
+};

--- a/packages/language-server/src/completions/debug-twig/parse-sections.ts
+++ b/packages/language-server/src/completions/debug-twig/parse-sections.ts
@@ -1,0 +1,76 @@
+import { TwigDebugInfo } from './types';
+
+const sectionLineRegex: Record<keyof TwigDebugInfo, RegExp> = {
+  Filters: /^\* (?<identifier>[a-zA-Z_][a-zA-Z0-9_]*)(?:\((?<args>[^)]*)\))?/,
+  Functions: /^\* (?<identifier>[a-zA-Z_][a-zA-Z0-9_]*)\((?<args>[^)]*)\)/,
+  Globals: /^\* (?<identifier>[a-zA-Z_][a-zA-Z0-9_]*) = (?<args>.+)/,
+  Tests: /^\* (?<identifier>[a-z ]+)/,
+};
+
+const headerRegex = /^([A-Za-z ]+)$/;
+
+
+export const parseSections = (input: string): TwigDebugInfo => {
+  const sections: TwigDebugInfo = {
+    Filters: [],
+    Functions: [],
+    Globals: [],
+    Tests: [],
+  };
+
+  const sectionNames = Object.keys(sections);
+
+  let currentSectionName: keyof TwigDebugInfo | '' = '';
+
+  const lines = input.split('\n').map((line) => line.trim());
+
+  for (const line of lines) {
+    const sectionHeaderMatch = line.match(headerRegex);
+    if (sectionHeaderMatch) {
+      currentSectionName = sectionHeaderMatch[1].trim() as keyof TwigDebugInfo;
+      sections[currentSectionName] = [];
+      continue;
+    }
+
+    if (!currentSectionName || !sectionNames.includes(currentSectionName)) {
+      continue;
+    }
+
+    const sectionLineMatch = line.match(sectionLineRegex[currentSectionName]);
+    if (!sectionLineMatch) {
+      continue;
+    }
+
+    const { identifier, args } = sectionLineMatch.groups!;
+
+    if (currentSectionName === 'Globals') {
+      sections[currentSectionName].push({
+        identifier,
+        value: args,
+      });
+
+      continue;
+    }
+
+    if (currentSectionName === 'Tests') {
+      sections[currentSectionName].push(identifier);
+      continue;
+    }
+
+    const argsArr = (args || '').split(',')
+      .map((arg) => {
+        const [identifier, defaultValue] = arg.trim().split('=');
+        return {
+          identifier,
+          defaultValue,
+        };
+      });
+
+    sections[currentSectionName].push({
+      identifier,
+      arguments: argsArr,
+    });
+  }
+
+  return sections;
+};

--- a/packages/language-server/src/completions/debug-twig/types.ts
+++ b/packages/language-server/src/completions/debug-twig/types.ts
@@ -1,0 +1,21 @@
+export type FunctionArgument = {
+  identifier: string,
+  defaultValue?: string,
+};
+
+export type TwigFunctionLike = {
+  identifier: string;
+  arguments: FunctionArgument[];
+};
+
+export type TwigVariable = {
+  identifier: string;
+  value: string;
+};
+
+export type TwigDebugInfo = {
+  Filters: TwigFunctionLike[];
+  Functions: TwigFunctionLike[];
+  Globals: TwigVariable[];
+  Tests: string[];
+};

--- a/packages/language-server/src/completions/filters.ts
+++ b/packages/language-server/src/completions/filters.ts
@@ -1,16 +1,28 @@
 import { CompletionItem, CompletionItemKind } from 'vscode-languageserver/node';
 import { SyntaxNode } from 'web-tree-sitter';
 import { twigFilters } from '../common';
+import { TwigFunctionLike } from './debug-twig';
 
-const completions: CompletionItem[] = twigFilters.map((item) =>
-  Object.assign({}, item, {
-    kind: CompletionItemKind.Function,
-    detail: 'filter',
-  })
-);
+const commonCompletionItem: Partial<CompletionItem> = {
+  kind: CompletionItemKind.Function,
+  detail: 'filter',
+};
 
-export function filters(cursorNode: SyntaxNode) {
+const completions: CompletionItem[] = twigFilters.map((item) => ({
+  ...commonCompletionItem,
+  ...item,
+}));
+
+export function filters(cursorNode: SyntaxNode, filters: TwigFunctionLike[]) {
   if (cursorNode.text === '|') {
-    return completions;
+    const completionsPhp = filters.map((func): CompletionItem => ({
+      ...commonCompletionItem,
+      label: func.identifier,
+    }));
+
+    return [
+      ...completions.filter(comp => !completionsPhp.find(compPhp => compPhp.label === comp.label)),
+      ...completionsPhp,
+    ];
   }
 }

--- a/packages/language-server/src/completions/global-variables.ts
+++ b/packages/language-server/src/completions/global-variables.ts
@@ -1,17 +1,30 @@
 import { CompletionItem, CompletionItemKind } from 'vscode-languageserver/node';
 import { SyntaxNode } from 'web-tree-sitter';
 import { twigGlobalVariables } from '../common';
+import { TwigVariable } from './debug-twig';
 import { isEmptyEmbedded } from '../utils/is-empty-embedded';
 
-const completions: CompletionItem[] = twigGlobalVariables.map((item) =>
-  Object.assign({}, item, {
-    kind: CompletionItemKind.Variable,
-    detail: 'global variable',
-  })
-);
+const commonCompletionItem: Partial<CompletionItem> = {
+  kind: CompletionItemKind.Variable,
+  commitCharacters: ['|', '.'],
+  detail: 'global variable',
+};
 
-export function globalVariables(cursorNode: SyntaxNode) {
+const completions: CompletionItem[] = twigGlobalVariables.map((item) => ({
+  ...commonCompletionItem,
+  ...item,
+}));
+
+export function globalVariables(cursorNode: SyntaxNode, globals: TwigVariable[]) {
   if (cursorNode.type === 'variable' || isEmptyEmbedded(cursorNode)) {
-    return completions;
+    const completionsPhp = globals.map((variable): CompletionItem => ({
+      ...commonCompletionItem,
+      label: variable.identifier,
+    }));
+
+    return [
+      ...completions.filter(comp => !completionsPhp.find(compPhp => compPhp.label === comp.label)),
+      ...completionsPhp,
+    ];
   }
 }

--- a/packages/language-server/src/configuration/configuration-manager.ts
+++ b/packages/language-server/src/configuration/configuration-manager.ts
@@ -17,8 +17,6 @@ export class ConfigurationManager {
     const config: LanguageServerSettings | undefined = settings?.[this.configurationSection];
 
     const phpBinConsoleCommand = config?.completion?.phpBinConsoleCommand?.trim();
-    if (phpBinConsoleCommand) {
-      this.server.completionProvider.initializeGlobalsFromCommand(phpBinConsoleCommand);
-    }
+    await this.server.completionProvider.initializeGlobalsFromCommand(phpBinConsoleCommand);
   }
 }

--- a/packages/language-server/src/configuration/configuration-manager.ts
+++ b/packages/language-server/src/configuration/configuration-manager.ts
@@ -15,5 +15,10 @@ export class ConfigurationManager {
 
   async onDidChangeConfiguration({ settings }: DidChangeConfigurationParams) {
     const config: LanguageServerSettings | undefined = settings?.[this.configurationSection];
+
+    const phpBinConsoleCommand = config?.completion?.phpBinConsoleCommand?.trim();
+    if (phpBinConsoleCommand) {
+      this.server.completionProvider.initializeGlobalsFromCommand(phpBinConsoleCommand);
+    }
   }
 }

--- a/packages/language-server/src/configuration/language-server-settings.ts
+++ b/packages/language-server/src/configuration/language-server-settings.ts
@@ -1,2 +1,5 @@
 export type LanguageServerSettings = {
+  completion: {
+    phpBinConsoleCommand: string,
+  },
 };

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -17,19 +17,20 @@ import { SemanticTokensProvider } from './semantic-tokens/semantic-tokens-provid
 import { ConfigurationManager } from './configuration/configuration-manager';
 
 export class Server {
-  connection: Connection;
-  documents: TextDocuments<TextDocument>;
+  readonly connection: Connection;
+  readonly documents: TextDocuments<TextDocument>;
   documentCache!: DocumentCache;
   workspaceFolder!: WorkspaceFolder;
 
   clientCapabilities!: ClientCapabilities;
+  completionProvider: CompletionProvider;
 
   constructor(connection: Connection) {
     this.connection = connection;
     this.documents = new TextDocuments(TextDocument);
 
     new HoverProvider(this);
-    new CompletionProvider(this);
+    this.completionProvider = new CompletionProvider(this);
     new SignatureHelpProvider(this);
     new SemanticTokensProvider(this);
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -38,6 +38,10 @@
     "configuration": {
       "title": "Modern Twig",
       "properties": {
+        "modernTwig.completion.phpBinConsoleCommand": {
+          "type": "string",
+          "markdownDescription": "Shell command that will be used for PHP command execution. \n\ne.g. `php bin/console` \n\nSee: https://symfony.com/doc/current/templates.html#inspecting-twig-information"
+        }
       }
     },
     "languages": [


### PR DESCRIPTION
This PR adds property `vscode-twig.completion.debugTwigCommand` in extension configuration which is executed on extension activation. 

The ouput of this command is parsed line-by-line and is used for completion inside of Twig templates.

See: https://symfony.com/doc/current/templates.html#inspecting-twig-information