### PR TITLE
Remove redundant `?` operator.

### DIFF
--- a/packages/language-server/src/completions/for-loop.ts
+++ b/packages/language-server/src/completions/for-loop.ts
@@ -11,7 +11,7 @@ export function forLoop(cursorNode: SyntaxNode) {
   if (
     cursorNode.text === '.' &&
     cursorNode.previousSibling?.type === 'variable' &&
-    cursorNode.previousSibling?.text === 'loop'
+    cursorNode.previousSibling.text === 'loop'
   ) {
     return forLoopProperties;
   }


### PR DESCRIPTION
The `cursorNode.previousSibling?.type === 'variable'` line also ensures that `previousSibling` is not empty.