### PR TITLE
Pass only `workspaceFolder` to `DocumentCache` ctor.

### DIFF
--- a/packages/language-server/src/document-cache.ts
+++ b/packages/language-server/src/document-cache.ts
@@ -1,9 +1,8 @@
 import { URI } from 'vscode-uri';
-import { Server } from './server';
 import readDir from './utils/read-dir';
 import { parseTwig } from './utils/parse-twig';
 import { readFile } from 'fs/promises';
-import { DocumentUri } from 'vscode-languageserver';
+import { DocumentUri, WorkspaceFolder } from 'vscode-languageserver';
 import { fsPathToDocumentUri } from './utils/fs-path-to-document-uri';
 import Parser from 'web-tree-sitter';
 
@@ -35,17 +34,17 @@ export class Document {
 }
 
 export class DocumentCache {
-  server: Server;
+  workspaceFolder!: WorkspaceFolder;
   documents: Map<DocumentUri, Document> = new Map();
 
-  constructor(server: Server) {
-    this.server = server;
+  constructor(workspaceFolder: WorkspaceFolder) {
+    this.workspaceFolder = workspaceFolder;
 
     this.initDocuments();
   }
 
   async initDocuments() {
-    const iterator = readDir(URI.parse(this.server.workspaceFolder.uri).fsPath);
+    const iterator = readDir(URI.parse(this.workspaceFolder.uri).fsPath);
     const reIsTwig = /.twig$/i;
 
     for await (const filePath of iterator) {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -32,7 +32,7 @@ export class Server {
     // Bindings
     connection.onInitialize((initializeParams: InitializeParams) => {
       this.workspaceFolder = initializeParams.workspaceFolders![0];
-      this.documentCache = new DocumentCache(this);
+      this.documentCache = new DocumentCache(this.workspaceFolder);
 
       const capabilities: ServerCapabilities = {
         hoverProvider: true,


### PR DESCRIPTION
`Server` knowledge may be a bit redundant for `DocumentCache` class.