### PR TITLE
Add completion support for empty embedded.

### DIFF
--- a/packages/language-server/src/completions/functions.ts
+++ b/packages/language-server/src/completions/functions.ts
@@ -6,6 +6,7 @@ import {
 } from 'vscode-languageserver/node';
 import { SyntaxNode } from 'web-tree-sitter';
 import { twigFunctions } from '../common';
+import { isEmptyEmbedded } from '../utils/is-empty-embedded';
 
 const triggerParameterHints = Command.create(
   'Trigger parameter hints',
@@ -23,7 +24,7 @@ const completions: CompletionItem[] = twigFunctions.map((item) =>
 );
 
 export function functions(cursorNode: SyntaxNode) {
-  if (cursorNode.type === 'variable' || cursorNode.type === 'function') {
+  if (['variable', 'function'].includes(cursorNode.type) || isEmptyEmbedded(cursorNode)) {
     return completions;
   }
 }

--- a/packages/language-server/src/completions/global-variables.ts
+++ b/packages/language-server/src/completions/global-variables.ts
@@ -1,6 +1,7 @@
 import { CompletionItem, CompletionItemKind } from 'vscode-languageserver/node';
 import { SyntaxNode } from 'web-tree-sitter';
 import { twigGlobalVariables } from '../common';
+import { isEmptyEmbedded } from '../utils/is-empty-embedded';
 
 const completions: CompletionItem[] = twigGlobalVariables.map((item) =>
   Object.assign({}, item, {
@@ -10,7 +11,7 @@ const completions: CompletionItem[] = twigGlobalVariables.map((item) =>
 );
 
 export function globalVariables(cursorNode: SyntaxNode) {
-  if (cursorNode.type === 'variable') {
+  if (cursorNode.type === 'variable' || isEmptyEmbedded(cursorNode)) {
     return completions;
   }
 }

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -38,7 +38,7 @@ export class Server {
         hoverProvider: true,
         completionProvider: {
           resolveProvider: true,
-          triggerCharacters: ['"', "'", '|', '.'],
+          triggerCharacters: ['"', "'", '|', '.', '{'],
         },
         signatureHelpProvider: {
           triggerCharacters: ['(', ','],

--- a/packages/language-server/src/utils/is-empty-embedded.ts
+++ b/packages/language-server/src/utils/is-empty-embedded.ts
@@ -1,0 +1,5 @@
+import { SyntaxNode } from 'web-tree-sitter';
+
+export const isEmptyEmbedded = (node: SyntaxNode) => node.type === 'ERROR'
+  && node.childCount === 1
+  && node.firstChild!.type === 'embedded_begin';


### PR DESCRIPTION
`{{ | }}` -> Ctrl+Space now results in non-empty completion list.